### PR TITLE
Improve error handling

### DIFF
--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -90,9 +90,9 @@ class DeviceDiscoverer {
 
     location = location.substring(location.indexOf('http'));
 
-    var request = await HttpClient().getUrl(Uri.parse(location));
     try {
-      var response = await request.close();
+      final request = await HttpClient().getUrl(Uri.parse(location));
+      final response = await request.close();
       final deviceXml =
           XmlDocument.parse(await response.transform(utf8.decoder).join())
               .rootElement

--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -66,11 +66,15 @@ class DeviceDiscoverer {
     socket.listen((event) {
       if (event == RawSocketEvent.read) {
         final packet = socket.receive();
-
         if (packet == null) return;
 
-        final data = utf8.decode(packet.data);
-        final headers = data.split('\r\n');
+        final List<String> headers;
+        try {
+          headers = utf8.decode(packet.data).split('\r\n');
+        } on FormatException catch (e,st) {
+          _errors.addError(e, st);
+          return;
+        }
 
         if (headers.indexWhere((e) => e.contains('HTTP/1.1 200 OK')) == -1) {
           return;

--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -95,7 +95,12 @@ class DeviceDiscoverer {
     location = location.substring(location.indexOf('http'));
 
     try {
-      final request = await HttpClient().getUrl(Uri.parse(location));
+      final locationUri = Uri.parse(location);
+      if (locationUri.host.isEmpty) {
+        return;
+      }
+
+      final request = await HttpClient().getUrl(locationUri);
       final response = await request.close();
       final deviceXml =
           XmlDocument.parse(await response.transform(utf8.decoder).join())

--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -78,7 +78,7 @@ class DeviceDiscoverer {
 
         _addDevice(headers);
       }
-    });
+    }, onError: _errors.addError);
   }
 
   void _addDevice(List<String> headers) async {
@@ -118,7 +118,7 @@ class DeviceDiscoverer {
       var multicastAddress = _getMulticastAddress(socket.address.type);
       // Repeated 3 times beacuse UDP messages might be lost
       for (var i = 0; i < 3; i++) {
-        socket.send(data, multicastAddress, 1900);
+        runZonedGuarded(() => socket.send(data, multicastAddress, 1900), _errors.addError);
       }
     }
   }

--- a/lib/src/discovery.dart
+++ b/lib/src/discovery.dart
@@ -13,10 +13,22 @@ import 'package:xml/xml.dart';
 class DeviceDiscoverer {
   final _sockets = <RawDatagramSocket>[];
   final _devices = StreamController<Device>.broadcast();
+  final _errors = StreamController<void>.broadcast();
   static const _supportedAddressTypes = [
     InternetAddressType.IPv4,
     InternetAddressType.IPv6
   ];
+
+  ///
+  /// A stream of discovered UPnP devices.
+  ///
+  Stream<Device> get devices => _devices.stream;
+
+  ///
+  /// A stream of errors occurred during the discovery process.
+  /// These errors are not fatal and will not stop the discovery process.
+  ///
+  Stream<void> get errors => _errors.stream;
 
   ///
   /// Starts the Discoverer.
@@ -87,9 +99,8 @@ class DeviceDiscoverer {
               .getElement('device');
 
       if (deviceXml != null) _devices.add(Device.fromXml(deviceXml, location));
-    } on Exception catch (e) {
-      // If the device is not reachable, ignore it.  save something?
-      print('Error: $e while trying to get device from $location');
+    } on Exception catch (e, st) {
+      _errors.addError(e, st);
     }
   }
 


### PR DESCRIPTION
This PR improves error handling during discovery:
- Do not just print discovery errors, but put them on a stream
- Catch socket errors that would otherwise be uncaught and put them on a stream